### PR TITLE
Bruk eksternReferanseId til duplikatkontroll

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(Ktor2.Client.library("mock"))
+    testImplementation(Junit5.library("params"))
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/no/nav/dagpenger/behov/journalforing/journalpost/JournalpostApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/journalforing/journalpost/JournalpostApi.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.behov.journalforing.journalpost
 
 internal interface JournalpostApi {
-    suspend fun opprett(ident: String, dokumenter: List<Dokument>): Journalpost
+    suspend fun opprett(ident: String, dokumenter: List<Dokument>, eksternReferanseId: String): Journalpost
 
     data class Journalpost(
         val id: String

--- a/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalforingBehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalforingBehovLøserTest.kt
@@ -35,7 +35,7 @@ internal class JournalforingBehovLøserTest {
     fun `løser behov for å opprette ny journalpost for dagpenger`() {
         val sendteDokumenter = slot<List<JournalpostApi.Dokument>>()
         coEvery {
-            journalpostApi.opprett(any(), capture(sendteDokumenter))
+            journalpostApi.opprett(any(), capture(sendteDokumenter), any())
         } returns Journalpost("journalpost123")
 
         testRapid.sendTestMessage(dagpengerInnsending)
@@ -69,7 +69,7 @@ internal class JournalforingBehovLøserTest {
     fun `løser behov for å opprette ny journalpost for generell innsending`() {
         val sendteDokumenter = slot<List<JournalpostApi.Dokument>>()
         coEvery {
-            journalpostApi.opprett(any(), capture(sendteDokumenter))
+            journalpostApi.opprett(any(), capture(sendteDokumenter), any())
         } returns Journalpost("journalpost123")
 
         testRapid.sendTestMessage(generellInnsending)


### PR DESCRIPTION
Dokarkiv bruker eksternReferanseId til duplikatkontroll på sin side. Har de allerede opprettet en journalpost med samme eksternReferanseId så svarer de med en 409 Conflict og body for journalposten de har