### PR TITLE
Legg til behovløser for minidialog-journalføring

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/behov/journalforing/App.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/journalforing/App.kt
@@ -8,6 +8,7 @@ import no.nav.dagpenger.behov.journalforing.fillager.FillagerHttp
 import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApiHttp
 import no.nav.dagpenger.behov.journalforing.soknad.SoknadHttp
 import no.nav.dagpenger.behov.journalforing.tjenester.JournalforingBehovLøser
+import no.nav.dagpenger.behov.journalforing.tjenester.MinidialogJournalføringBehovLøser
 import no.nav.dagpenger.behov.journalforing.tjenester.RapporteringJournalføringBehovLøser
 import no.nav.dagpenger.behov.journalforing.tjenester.VedtaksbrevJournalføringBehovløser
 import no.nav.helse.rapids_rivers.RapidApplication
@@ -27,6 +28,10 @@ internal object App : RapidsConnection.StatusListener {
                 fillager = fillager,
                 journalpostApi = journalpostApi,
                 faktahenter = SoknadHttp(tokenProvider = dpSøknadTokenProvider),
+            )
+            MinidialogJournalføringBehovLøser(
+                rapidsConnection = it,
+                journalpostApi = journalpostApi,
             )
             RapporteringJournalføringBehovLøser(
                 rapidsConnection = it,

--- a/src/main/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/MinidialogJournalføringBehovLøser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/MinidialogJournalføringBehovLøser.kt
@@ -1,0 +1,141 @@
+package no.nav.dagpenger.behov.journalforing.tjenester
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
+import com.github.navikt.tbd_libs.rapids_and_rivers.River
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageMetadata
+import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.http.HttpStatusCode
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.slf4j.MDCContext
+import mu.KotlinLogging
+import mu.withLoggingContext
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi.Dokument
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi.Variant
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi.Variant.Filtype
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi.Variant.Format
+import java.util.Base64
+
+internal class MinidialogJournalføringBehovLøser(
+    rapidsConnection: RapidsConnection,
+    private val journalpostApi: JournalpostApi,
+) : River.PacketListener {
+    internal companion object {
+        private val logg = KotlinLogging.logger {}
+        private val sikkerlogg = KotlinLogging.logger("tjenestekall.MinidialogJournalføringBehovLøser")
+        internal const val BEHOV = "JournalføreMinidialog"
+    }
+
+    init {
+        River(rapidsConnection)
+            .apply {
+                precondition {
+                    it.requireValue("@event_name", "behov")
+                    it.requireAll("@behov", listOf(BEHOV))
+                    it.forbid("@løsning")
+                }
+                validate { it.requireKey("@behovId", "ident", "søknad_uuid") }
+                validate {
+                    it.require(BEHOV) { behov ->
+                        behov.required("skjemakode")
+                        behov.required("dialog_uuid")
+                        behov.required("tittel")
+                        behov.required("json")
+                        behov.required("pdf")
+                    }
+                }
+            }.register(this)
+    }
+
+    override fun onPacket(
+        packet: JsonMessage,
+        context: MessageContext,
+        metadata: MessageMetadata,
+        meterRegistry: MeterRegistry,
+    ) {
+        val søknadId = packet["søknad_uuid"].asText()
+        val dialogId = packet[BEHOV]["dialog_uuid"].asText()
+        val ident = packet["ident"].asText()
+        val behovId = packet["@behovId"].asText()
+
+        withLoggingContext(
+            "søknadId" to søknadId,
+            "dialogId" to dialogId,
+            "behovId" to behovId,
+        ) {
+            try {
+                logg.info("Mottok behov for ny journalpost for dialog med id $dialogId for søknad med id $søknadId")
+                runBlocking(MDCContext()) {
+                    val brevkode = packet[BEHOV]["skjemakode"].asText()
+                    val tittel = packet[BEHOV]["tittel"].asText()
+                    val json = packet[BEHOV]["json"].asText()
+                    val pdf = packet[BEHOV]["pdf"].asText()
+
+                    val dokumenter: List<Dokument> =
+                        listOf(
+                            opprettDokument(
+                                brevkode,
+                                tittel,
+                                json.encodeToByteArray(),
+                                Base64.getDecoder().decode(pdf),
+                            ),
+                        )
+
+                    sikkerlogg.info { "Oppretter journalpost med $dokumenter" }
+                    sikkerlogg.info { "Oppretter journalpost basert på ${packet.toJson()}" }
+
+                    val resultat =
+                        journalpostApi.opprett(
+                            ident = ident,
+                            dokumenter = dokumenter,
+                            eksternReferanseId = behovId,
+                            forsøkFerdigstill = true,
+                            tittel = tittel,
+                        )
+                    packet["@løsning"] =
+                        mapOf(
+                            BEHOV to resultat.journalpostId,
+                        )
+                    context.publish(packet.toJson())
+                    logg.info { "Løser behov $BEHOV med journalpostId=${resultat.journalpostId}" }
+                }
+            } catch (e: ClientRequestException) {
+                if (e.response.status == HttpStatusCode.InternalServerError) {
+                    sikkerlogg.warn(e) { "Feilet for '$ident'. Hvis dette er i dev, forsøk å importer identen på nytt i Dolly." }
+                }
+                if (behovId in listOf("behovid")) {
+                    logg.error { "Skipper feil for behovId $behovId" }
+                } else {
+                    throw e
+                }
+            }
+        }
+    }
+
+    private fun opprettDokument(
+        brevkode: String,
+        tittel: String,
+        json: ByteArray,
+        pdf: ByteArray,
+    ): Dokument =
+        Dokument(
+            brevkode = brevkode,
+            tittel = tittel,
+            varianter =
+                listOf(
+                    Variant(
+                        filtype = Filtype.JSON,
+                        format = Format.ORIGINAL,
+                        fysiskDokument = json,
+                    ),
+                    Variant(
+                        filtype = Filtype.PDFA,
+                        format = Format.ARKIV,
+                        fysiskDokument = pdf,
+                    ),
+                ),
+        )
+}

--- a/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/MinidialogJournalføringBehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/MinidialogJournalføringBehovLøserTest.kt
@@ -1,0 +1,94 @@
+package no.nav.dagpenger.behov.journalforing.tjenester
+
+import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
+import io.ktor.utils.io.core.toByteArray
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApiHttp.Resultat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Base64
+import kotlin.test.assertContentEquals
+
+internal class MinidialogJournalføringBehovLøserTest {
+    private val behov = "JournalføreMinidialog"
+    private val søknadId = "19185bc3-7752-48c3-9886-c429c76b5052"
+    private val behovId = "34f6743c-bd9a-4902-ae68-fae0171b1e79"
+    private val dialogId = "34f6743c-bd9a-4902-ae68-fae0171b1e90"
+    private val ident = "01020312345"
+    private val base64EncodedPdf = "UERG"
+
+    private val journalpostId = "journalpost123"
+    private val json = "{\"key1\": \"value1\"}"
+
+    private val minidialogJournalføringBehov =
+        """
+        {
+          "@event_name": "behov",
+          "@behovId": "$behovId",
+          "@behov": [
+            "$behov"
+          ],
+          "søknad_uuid": "$søknadId",
+          "ident": "$ident",
+          "JournalføreMinidialog": {
+            "skjemakode": "04-01.03",
+            "dialog_uuid": "$dialogId",
+            "tittel": "Arbeidsforhold",
+            "json": "{\"key1\": \"value1\"}",
+            "pdf": "$base64EncodedPdf"
+          },
+          "@id": "30ef9625-196a-445b-9b4e-67e0e6a5118d",
+          "@opprettet": "2023-10-23T18:53:08.056035121",
+          "system_read_count": 0,
+          "system_participating_services": [
+            {
+                "id": "c1116672-9057-406b-93e1-7198f7282126",
+                "time": "2022-09-26T09:47:25.411111"
+            }
+          ]
+        }
+        """.trimIndent().replace("\n", "")
+
+    private val journalpostApi = mockk<JournalpostApi>()
+    private val testRapid =
+        TestRapid().also {
+            MinidialogJournalføringBehovLøser(it, journalpostApi)
+        }
+
+    @Test
+    fun `løser behov for å opprette ny journalpost for minidialog`() {
+        val sendteDokumenter = slot<List<JournalpostApi.Dokument>>()
+        coEvery {
+            journalpostApi.opprett(
+                ident = eq(ident),
+                dokumenter = capture(sendteDokumenter),
+                eksternReferanseId = eq(behovId),
+                forsøkFerdigstill = eq(true),
+                tittel = "Arbeidsforhold",
+            )
+        } returns Resultat(journalpostId, true, emptyList(), "Journalpost ferdigstilt")
+
+        testRapid.sendTestMessage(minidialogJournalføringBehov)
+
+        assertEquals(1, sendteDokumenter.captured.size)
+        with(sendteDokumenter.captured[0]) {
+            assertEquals("04-01.03", this.brevkode)
+            assertEquals("Arbeidsforhold", this.tittel)
+            assertEquals(2, this.varianter.size)
+            assertEquals(JournalpostApi.Variant.Filtype.JSON, this.varianter[0].filtype)
+            assertEquals(JournalpostApi.Variant.Format.ORIGINAL, this.varianter[0].format)
+            assertContentEquals(json.toByteArray(), this.varianter[0].fysiskDokument)
+            assertEquals(JournalpostApi.Variant.Filtype.PDFA, this.varianter[1].filtype)
+            assertEquals(JournalpostApi.Variant.Format.ARKIV, this.varianter[1].format)
+            assertContentEquals(Base64.getDecoder().decode(base64EncodedPdf), this.varianter[1].fysiskDokument)
+        }
+
+        with(testRapid.inspektør) {
+            assertEquals(1, size)
+            assertEquals(journalpostId, field(0, "@løsning")["JournalføreMinidialog"].asText())
+        }
+    }
+}


### PR DESCRIPTION
Behovet skal sendes ut fra dp-soknad-orkestrator når en bruker har sendt inn en minidialog.
Den forventer å få en ferdig base64-enkodet pdf.