### PR TITLE
Støtt original-format med json for orkestrator-søknad

### DIFF
--- a/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalførSøknadPdfOgVedleggBehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalførSøknadPdfOgVedleggBehovLøserTest.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.behov.journalforing.tjenester
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -18,6 +19,8 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.dagpenger.behov.journalforing.fillager.Fillager
 import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi.Variant.Filtype.JSON
+import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApi.Variant.Format.ORIGINAL
 import no.nav.dagpenger.behov.journalforing.journalpost.JournalpostApiHttp.Resultat
 import no.nav.dagpenger.behov.journalforing.tjenester.JournalførSøknadPdfOgVedleggBehovLøser.Companion.BEHOV
 import org.intellij.lang.annotations.Language
@@ -38,7 +41,7 @@ internal class JournalførSøknadPdfOgVedleggBehovLøserTest {
         }
 
     @Test
-    fun `JournalførSøknadPdfOgVedleggBehovLøser løser behov som forventet`() {
+    fun `JournalførSøknadPdfOgVedleggBehovLøser løser behov som forventet for pdf-variant`() {
         val sendteDokumenter = slot<List<JournalpostApi.Dokument>>()
         coEvery {
             journalpostApi.opprett(any(), capture(sendteDokumenter), any(), any(), any())
@@ -76,6 +79,29 @@ internal class JournalførSøknadPdfOgVedleggBehovLøserTest {
                 true,
                 any(),
             )
+        }
+    }
+
+    @Test
+    fun `JournalførSøknadPdfOgVedleggBehovLøser løser behov som forventet med json-variant`() {
+        val forventetJsonString = "{\"versjon_navn\":\"Dagpenger\",\"søknad_uuid\":\"123e4567-e89b-12d3-a456-426614174000\"}"
+        val sendteDokumenter = slot<List<JournalpostApi.Dokument>>()
+        coEvery {
+            journalpostApi.opprett(any(), capture(sendteDokumenter), any(), any(), any())
+        } returns Resultat("730212311", false, emptyList(), "Journalpost ferdigstilt")
+
+        testRapid.sendTestMessage(meldingMedJsonVariant)
+
+        sendteDokumenter.captured.size shouldBe 1
+        with(sendteDokumenter.captured[0]) {
+            this.brevkode shouldBe "NAV 04-01.03"
+            this.tittel shouldBe "Søknad om dagpenger (ikke permittert)"
+            this.varianter.size shouldBe 3
+            this.varianter[2].let { variant ->
+                variant.filtype shouldBe JSON
+                variant.format shouldBe ORIGINAL
+                variant.fysiskDokument shouldBe jacksonObjectMapper().writeValueAsBytes(forventetJsonString)
+            }
         }
     }
 
@@ -292,6 +318,54 @@ internal class JournalførSøknadPdfOgVedleggBehovLøserTest {
               "time": "2022-09-26T09:47:25.411111"
             }
           ]
+        }
+        """.trimIndent()
+
+    @Language("JSON")
+    val meldingMedJsonVariant =
+        """
+        {
+          "@event_name" : "behov",
+          "@behovId" : "c1ba3588-e831-4129-9d41-3e83d777c1b9",
+          "@behov" : [ "journalfør_søknad_pdf_og_vedlegg" ],
+          "søknadId" : "123e4567-e89b-12d3-a456-426614174000",
+          "ident" : "12345678903",
+          "type" : "NY_DIALOG",
+          "journalfør_søknad_pdf_og_vedlegg" : {
+            "hovedDokument" : {
+              "skjemakode" : "04-01.03",
+              "varianter" : [ {
+                "uuid" : "3e0e0132-29c8-4183-a12d-55c903588158",
+                "filnavn" : "netto.pdf",
+                "urn" : "urn:vedlegg:soknadId/netto.pdf",
+                "json" : null,
+                "variant" : "ARKIV",
+                "type" : "PDF"
+              }, {
+                "uuid" : "69be2215-8ee9-4b6b-b349-ff8e1df422a5",
+                "filnavn" : "brutto.pdf",
+                "urn" : "urn:vedlegg:soknadId/brutto.pdf",
+                "json" : null,
+                "variant" : "FULLVERSJON",
+                "type" : "PDF"
+              }, {
+                "uuid" : "f575bd00-e93f-4a75-b22c-9bd818c2cebc",
+                "filnavn" : "json",
+                "urn" : "urn:nav:dagpenger:json",
+                "json" : "{\"versjon_navn\":\"Dagpenger\",\"søknad_uuid\":\"123e4567-e89b-12d3-a456-426614174000\"}",
+                "variant" : "ORIGINAL",
+                "type" : "JSON"
+              } ]
+            },
+            "dokumenter" : [ ]
+          },
+          "@id" : "4df3f1a1-24ff-4c87-97b1-100cdc10a2df",
+          "@opprettet" : "2026-02-11T18:14:41.897835485",
+          "system_read_count" : 0,
+          "system_participating_services" : [ {
+            "id" : "4df3f1a1-24ff-4c87-97b1-100cdc10a2df",
+            "time" : "2026-02-11T18:14:41.897835485"
+          } ]
         }
         """.trimIndent()
 }


### PR DESCRIPTION
Da kan vi journalføre en maskinlesbar json-utgave av søknaden.
Dette sendes videre i dp-mottak sin "innsending_ferdigstilt"-melding, sånn at andre apper får tak i søknadId.