### PR TITLE
Legg til NAVe-prefix på hoveddokument ved ettersending

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalførEttersendingBehovLøser.kt
+++ b/src/main/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalførEttersendingBehovLøser.kt
@@ -78,8 +78,15 @@ internal class JournalførEttersendingBehovLøser(
             }
             if (behovIdSkipSet.contains(behovId)) return
             runBlocking(MDCContext()) {
+                val dokumenterFraPacket = packet[BEHOV]["dokumenter"].toList()
                 val dokumenter: List<Dokument> =
-                    packet[BEHOV]["dokumenter"].map { it.toDokument(ident) }
+                    dokumenterFraPacket.mapIndexed { index, node ->
+                        if (index == 0) {
+                            node.toDokument(ident, innsendingType.brevkode(node.skjemakode()))
+                        } else {
+                            node.toDokument(ident)
+                        }
+                    }
 
                 sikkerlogg.info { "Oppretter journalpost for ettersending med $dokumenter" }
                 sikkerlogg.info { "Oppretter journalpost for ettersending basert på ${packet.toJson()}" }

--- a/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalførEttersendingBehovLøserTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/behov/journalforing/tjenester/JournalførEttersendingBehovLøserTest.kt
@@ -46,7 +46,7 @@ class JournalførEttersendingBehovLøserTest {
         assert(sendteDokumenter.captured.size == 2)
 
         with(sendteDokumenter.captured[0]) {
-            this.brevkode shouldBe "DOK1"
+            this.brevkode shouldBe "NAVe DOK1"
             this.tittel shouldBe "Ukjent dokumentittel"
             this.varianter.size shouldBe 2
         }
@@ -102,7 +102,7 @@ class JournalførEttersendingBehovLøserTest {
           ],
           "søknadId": "19185bc3-7752-48c3-9886-c429c76b5041",
           "ident": "12345678913",
-          "type": "NY_DIALOG",
+          "type": "ETTERSENDING_TIL_DIALOG",
           "innsendingId": "d0664505-e546-4cef-9e3f-8f49b85afb58",
           "journalfør_ettersending_av_dokumentasjon": {
             "dokumenter": [


### PR DESCRIPTION
JournalførEttersendingBehovLøser hadde brevkode()-metoden definert, men kalte den aldri — brukte raw skjemakode direkte som brevkode i Joark. dp-mottak kategoriserte dermed ettersendinger som UkjentSkjemaKode og sendte ikke Søknadsdata-behov.

Fiks: bruk innsendingType.brevkode() på første dokument (hoveddokumentet) slik JournalforingBehovLøser allerede gjør for vanlige søknader.

Vedleggsdokumenter (index > 0) beholder sine originale skjemakoder.